### PR TITLE
WIP: Make it work on vagrant machine

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "vendor/ggpyjobs"]
 	path = vendor/ggpyjobs
-	url = https://github.com/dsjoerg/ggpyjobs.git
+	url = https://github.com/nickelsen/ggpyjobs.git
+	branch = vagrant


### PR DESCRIPTION
Use ggpyjobs and gems that work on Ubuntu 14.04 and git repo urls that don't require keys to clone.

ggpyjobs ref needs to be updated to the merge-commit of this PR before merge: https://github.com/dsjoerg/ggpyjobs/pull/8
